### PR TITLE
Use zip-files as the default backup storage type

### DIFF
--- a/companion/api/backup.py
+++ b/companion/api/backup.py
@@ -13,6 +13,7 @@ import boto3
 from elasticsearch import helpers
 
 from . import util
+from .. import error
 
 __all__ = ['s3']
 logger = logging.getLogger(__name__)
@@ -48,10 +49,14 @@ def _save_hit(root_path, hit):
 
 
 def _fetch_and_tar(url, index_name):
-    logger.info('Fetching index documents {}'.format(index_name))
-    tmpdir = tempfile.mkdtemp()
-    logger.info('Storing documents in {}'.format(tmpdir))
     client = util.get_client(url)
+    if not client.indices.exists(index_name):
+        logger.warn('Index "{}" does not exist, ignoring it'.format(index_name))
+        return None, None
+
+    tmpdir = tempfile.mkdtemp()
+    logger.info('Fetching index documents {}'.format(index_name))
+    logger.info('Storing documents in {}'.format(tmpdir))
     body = {'size': 1000}
     hits_iter = helpers.scan(client,
                              index=index_name,
@@ -70,9 +75,80 @@ def _fetch_and_tar(url, index_name):
     return tmpdir, tar_files
 
 
-def s3(url, index_name, region, bucket_name, user_key, secret_key):
+def _flush_zips(index_dirs, target_dir):
+    zip_files = []
+    for index_dir in index_dirs:
+        zip_files.append(util.zip_directory(index_dir, target_dir,
+                                            delete_original=True,
+                                            append=True))
+    return zip_files
+
+
+def _fetch_and_zip(url, index_name, batch_size=10000):
+    client = util.get_client(url)
+    if not client.indices.exists(index_name):
+        logger.warn('Index "{}" does not exist, ignoring it'.format(index_name))
+        return None, None
+
+    tmpdir = tempfile.mkdtemp()
+
+    logger.info('Fetching index documents {}'.format(index_name))
+    logger.info('Storing documents in {}'.format(tmpdir))
+
+    body = {'size': 1000}
+    hits_iter = helpers.scan(client,
+                             index=index_name,
+                             query=body,
+                             scroll='5m')
+    index_dirs = set()
+    zip_files = set()
+    processed_in_batch = 0
+    for hit in hits_iter:
+        doc_path = _save_hit(tmpdir, hit)
+        index_dirs.add(os.path.dirname(doc_path))
+        processed_in_batch += 1
+        if processed_in_batch == batch_size:
+            zip_files.update(_flush_zips(index_dirs, tmpdir))
+            processed_in_batch = 0
+            index_dirs.clear()
+    zip_files.update(_flush_zips(index_dirs, tmpdir))
+    logger.info('Done fetching documents and creating zip files')
+    return tmpdir, list(zip_files)
+
+
+def s3(url, index_name, region, bucket_name, user_key, secret_key,
+       filetype='zip'):
+    """Make a backup of an Elasticsearch index and send the data to
+    to Amazon S3. The data format can be either tar.gz-files or zip-files.
+
+    :param url: The full Elasticsearch url
+    :type url: str
+    :param index_name: The name of the index to backup.
+    :type index_name: str
+    :param region: The S3 region that the bucket is located in.
+    :type region: str
+    :param bucket_name: The S3 bucket name.
+    :type bucket_name: str
+    :param user_key: S3 username/access key
+    :type user_key: str
+    :param secret_key: S3 password/secret key
+    :type secret_key: str
+    :param filetype: Type of file to send to S3.
+    :type filetype: str
+
+    """
     logger.info('Starting S3 backup for index {}'.format(index_name))
-    tmpdir, tar_files = _fetch_and_tar(url, index_name)
+
+    if filetype == 'zip':
+        tmpdir, files = _fetch_and_zip(url, index_name)
+    elif filetype == 'tar':
+        tmpdir, files = _fetch_and_tar(url, index_name)
+    else:
+        raise error.CompanionException('Unknown filetype {}'.format(filetype))
+
+    if not files:
+        return logger.warn('No files to upload, exiting')
+
     backup_dir = 'clibackup/{:%Y/%m/%d_%H%M%S}'.format(now)
     logger.info('Starting s3 upload to {}'.format(backup_dir))
     s3 = boto3.resource('s3',
@@ -80,11 +156,11 @@ def s3(url, index_name, region, bucket_name, user_key, secret_key):
                         aws_access_key_id=user_key,
                         aws_secret_access_key=secret_key)
     bucket = s3.Bucket(bucket_name)
-    for tar_file in tar_files:
-        tar_filename = os.path.basename(tar_file)
-        logger.info('Uploading object to s3: {}'.format(tar_filename))
-        object_key = '{}_{}'.format(backup_dir, tar_filename)
-        with open(tar_file, 'rb') as data:
+    for f in files:
+        filename = os.path.basename(f)
+        logger.info('Uploading object to s3: {}'.format(filename))
+        object_key = '{}_{}'.format(backup_dir, filename)
+        with open(f, 'rb') as data:
             bucket.put_object(Key=object_key, Body=data)
     logger.info('Done uploading objects to s3. Starting cleanup')
     _cleanup(tmpdir)

--- a/companion/api/util.py
+++ b/companion/api/util.py
@@ -1,7 +1,9 @@
 """Common utility functions used across commands."""
 import os
 import json
+import shutil
 import tarfile
+import zipfile
 
 import certifi
 import elasticsearch
@@ -38,3 +40,50 @@ def tar_gz_directory(directory, target_path):
     with tarfile.open(tar_path, 'w:gz') as tar:
         tar.add(directory, directory_name)
     return tar_path
+
+
+def zip_directory(directory, target_path, append=False, delete_original=False):
+    """Zip the contents of a single directory.
+
+    The zip-file will have the same name as the basename of the directory.
+
+    :param directory: The directory to tar the contents of.
+    :type directory: str
+    :param target_path: The target of the compressed tar file.
+    :type target_path: str
+    :param append: Determine whether or not to append to an existing archive. If
+        False, a new archive will always be created. Default is False.
+    :type append: bool
+    :param delete_original: Determine whether or not to delete the directory
+        that was zipped. Default is False.
+    :type append: bool
+    :returns: The full path to the created zip file.
+
+    """
+    full_directory = os.path.abspath(os.path.normpath(directory))
+    directory_name = os.path.basename(full_directory)
+    zip_path = '{}/{}.zip'.format(target_path, directory_name)
+    if os.path.exists(zip_path) and not append:
+        os.remove(zip_path)
+
+    mode = 'a' if append else 'w'
+    with zipfile.ZipFile(zip_path, mode=mode,
+                         compression=zipfile.ZIP_DEFLATED) as zf:
+        for dirpath, _, filenames in os.walk(full_directory):
+            for filename in filenames:
+                # Find the full filepath for the filename
+                # For storing the file in the zip, remove the part of the
+                # full path that contains directory structures above the
+                # directory being zipped
+                # For example, /home/user/mydirectory/myfile.txt becomes
+                # mydirectory/myfile.txt in the zipfile.
+                full_filepath = os.path.join(dirpath, filename)
+                short_filepath = os.path.relpath(full_filepath,
+                                                 start=full_directory)
+                short_filepath = os.path.join(directory_name, short_filepath)
+                zf.write(full_filepath, short_filepath)
+
+    if delete_original:
+        shutil.rmtree(directory)
+
+    return zip_path

--- a/test/test_api_backup.py
+++ b/test/test_api_backup.py
@@ -1,0 +1,107 @@
+"""Backup test functions."""
+import os
+import json
+import shutil
+import tempfile
+from unittest import TestCase
+
+from companion import error
+from companion.api import backup, util
+
+from . import create_test_data
+
+
+class TempfileTestCase(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+
+class TestSaveHit(TempfileTestCase):
+
+    def test_save_hit(self):
+        """It should save a hit as a JSON file."""
+        hit = {
+            '_id': 'abcd',
+            '_index': 'myindex',
+            '_type': 'mytype',
+            '_source': {
+                'myfield': 'myvalue'
+            }
+        }
+        target = os.path.join(self.tmpdir,
+                              'myindex_mytype/myindex_mytype_abcd.json')
+
+        saved_target = backup._save_hit(self.tmpdir, hit)
+        self.assertEqual(saved_target, target)
+        self.assertTrue(os.path.exists(target))
+        with open(target) as f:
+            hit_loaded = json.loads(f.read())
+            self.assertEqual(hit, hit_loaded)
+
+
+class TestFetchAndZip(TempfileTestCase):
+
+    def test_not_exists(self):
+        """It should not crash on indexes that do not exist."""
+        tmpdir, zipfiles = backup._fetch_and_zip('http://localhost:9200',
+                                                 'fooindexname')
+        self.assertIsNone(tmpdir)
+        self.assertIsNone(zipfiles)
+
+    def test_non_empty(self):
+        """It should create zip-files by default."""
+        create_test_data()
+        tmpdir, zipfiles = backup._fetch_and_zip('http://localhost:9200',
+                                                 'companiontest')
+        self.assertEqual(len(zipfiles), 2)
+        zip1 = os.path.join(tmpdir, 'companiontest_simple.zip')
+        zip2 = os.path.join(tmpdir, 'companiontest_advanced.zip')
+        self.assertIn(zip1, zipfiles)
+        self.assertIn(zip2, zipfiles)
+
+    def test_non_empty(self):
+        """It should create zip-files by default."""
+        create_test_data()
+        tmpdir, zipfiles = backup._fetch_and_zip('http://localhost:9200',
+                                                 'companiontest')
+        self.assertEqual(len(zipfiles), 2)
+        zip1 = os.path.join(tmpdir, 'companiontest_simple.zip')
+        zip2 = os.path.join(tmpdir, 'companiontest_advanced.zip')
+        self.assertIn(zip1, zipfiles)
+        self.assertIn(zip2, zipfiles)
+
+    def test_non_empty_small_batchsize(self):
+        """It should create zip-files by default."""
+        create_test_data()
+        tmpdir, zipfiles = backup._fetch_and_zip('http://localhost:9200',
+                                                 'companiontest',
+                                                 batch_size=1)
+        self.assertEqual(len(zipfiles), 2)
+        zip1 = os.path.join(tmpdir, 'companiontest_simple.zip')
+        zip2 = os.path.join(tmpdir, 'companiontest_advanced.zip')
+        self.assertIn(zip1, zipfiles)
+        self.assertIn(zip2, zipfiles)
+
+
+class TestFetchAndTar(TempfileTestCase):
+
+    def test_not_exists(self):
+        """It should not crash on indexes that do not exist."""
+        tmpdir, tarfiles = backup._fetch_and_tar('http://localhost:9200',
+                                                 'fooindexname')
+        self.assertIsNone(tmpdir)
+        self.assertIsNone(tarfiles)
+
+    def test_non_empty(self):
+        """It should create zip-files by default."""
+        create_test_data()
+        tmpdir, tarfiles = backup._fetch_and_tar('http://localhost:9200',
+                                                 'companiontest')
+        self.assertEqual(len(tarfiles), 2)
+        tar1 = os.path.join(tmpdir, 'companiontest_simple.tar.gz')
+        tar2 = os.path.join(tmpdir, 'companiontest_advanced.tar.gz')
+        self.assertIn(tar1, tarfiles)
+        self.assertIn(tar2, tarfiles)

--- a/test/test_api_util.py
+++ b/test/test_api_util.py
@@ -1,7 +1,9 @@
 """Util test functions."""
 import os
+import uuid
 import shutil
 import tarfile
+import zipfile
 import tempfile
 from unittest import TestCase
 
@@ -61,3 +63,95 @@ class TestTarGzDirectory(TestCase):
         with open(check_filename) as f:
             s = f.read()
             self.assertEqual(s, 'This string will be compressed')
+
+
+class TestZipDirectory(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.compressdir = os.path.join(self.tmpdir, 'test/')
+        os.mkdir(self.compressdir)
+        self.create_file()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def create_file(self, filename=None):
+        if filename:
+            self.filename = filename
+        else:
+            self.filename = '{}.txt'.format(uuid.uuid4())
+        self.filepath = os.path.join(self.compressdir, self.filename)
+
+        # If the directory containing the full filepath does not exist, create
+        # all intermediary directories.
+        if not os.path.exists(os.path.dirname(self.filepath)):
+            os.makedirs(os.path.dirname(self.filepath))
+
+        with open(self.filepath, 'w') as f:
+            f.write('This string will be compressed')
+
+    def test_zip(self):
+        """It should compress a file and be able to decompress."""
+        zip_path = util.zip_directory(self.compressdir, self.tmpdir)
+
+        # Zip file should be smaller
+        self.assertLess(os.path.getsize(self.filepath),
+                        os.path.getsize(zip_path))
+
+        # Zip file should be able to decompress and have same contents as
+        # before.
+        checkdir = os.path.join(self.tmpdir, 'check/')
+        os.mkdir(checkdir)
+        check_filename = os.path.join(checkdir, 'test/{}'.format(self.filename))
+        with zipfile.ZipFile(zip_path) as f:
+            f.extractall(checkdir)
+
+        with open(check_filename) as f:
+            s = f.read()
+            self.assertEqual(s, 'This string will be compressed')
+
+    def test_zip_multi_level(self):
+        """It should support multiple directory levels."""
+        self.create_file('test1/test.txt')
+        self.create_file('test1/testsubdir/test.txt')
+        self.create_file('test2/test.txt')
+        zip_path = util.zip_directory(self.compressdir, self.tmpdir)
+        with zipfile.ZipFile(zip_path) as f:
+            names = f.namelist()
+            self.assertIn('test/test1/test.txt', names)
+            self.assertIn('test/test1/testsubdir/test.txt', names)
+            self.assertIn('test/test2/test.txt', names)
+
+    def test_zip_no_delete_original(self):
+        """It should not delete the original files by default."""
+        util.zip_directory(self.compressdir, self.tmpdir)
+        self.assertTrue(os.path.exists(self.filepath))
+
+    def test_zip_delete_original(self):
+        """It should delete the original files if specified."""
+        util.zip_directory(self.compressdir, self.tmpdir,
+                           delete_original=True)
+        self.assertFalse(os.path.exists(self.filepath))
+
+    def test_zip_no_append(self):
+        """It should not append files by default."""
+        util.zip_directory(self.compressdir, self.tmpdir,
+                           delete_original=True)
+        self.create_file()
+        zip_path = util.zip_directory(self.compressdir, self.tmpdir)
+        with zipfile.ZipFile(zip_path) as f:
+            self.assertEqual(len(f.namelist()), 1)
+
+    def test_zip_append(self):
+        """It should append files if specified."""
+        zip_path = util.zip_directory(self.compressdir, self.tmpdir,
+                                      delete_original=True, append=True)
+        with zipfile.ZipFile(zip_path) as f:
+            self.assertEqual(len(f.namelist()), 1)
+        self.create_file()
+        self.create_file()
+        self.create_file()
+        zip_path = util.zip_directory(self.compressdir, self.tmpdir,
+                                      append=True)
+        with zipfile.ZipFile(zip_path) as f:
+            self.assertEqual(len(f.namelist()), 4)


### PR DESCRIPTION
### The problem
The current backup scheme downloads uncompressed JSON documents and uses tar.gz files for compressing everything together. Some of our current indexes take up ~7GB of space for the uncompressed JSON files which was too much for Heroku dyno to handle.

### The "solution"
Use zip-files as the default storage type instead of tar-files and zip in batches rather than all at once.

Pros:
- zip-files can be incrementally updated which is not supported for tar-files.
- During testing, disk usage only climbed to ~1.3GB, a nice improvement over using ~7GB of space.

Cons:
- zip-files take up 3-5 times as much space than tar.gz files using the standard zlip method. For our indexes, they take of 1.3GB versus 300MB

### This PR

It changes the default storage type for backup files to zip-files rather than tar-files to allow incrementally creating the compressed archive rather than downloading everything before compressing.

Changes:
- Add utility function to zip a directory.
- Add functionality for fetching and zip'ing files incrementally in batches (default 10000 documents per batch).
- Add tests for backup API.